### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Html5 video player
+[![Run on Repl.it](https://repl.it/badge/github/TristHub/HTML5-video-player)](https://repl.it/github/TristHub/HTML5-video-player)
 ---------------------
 A video player made fully in html.
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@newtristanchann/HTML5-video-player).